### PR TITLE
janitor: fix HTTP host redirect to use Request.Host

### DIFF
--- a/pkg/handler/http.go
+++ b/pkg/handler/http.go
@@ -106,7 +106,12 @@ func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *HTTPHandler) handleRedirect(w http.ResponseWriter, r *http.Request) bool {
-	if r.URL.Hostname() != "" && r.URL.Hostname() != h.opts.Hostname {
+	// Server requests put the host in Request.Host; Request.URL.Host is empty.
+	host := r.Host
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		host = hostname
+	}
+	if host != "" && host != h.opts.Hostname {
 		destinationURL := new(url.URL)
 		*destinationURL = *r.URL
 		destinationURL.Host = h.opts.Hostname

--- a/pkg/handler/http_test.go
+++ b/pkg/handler/http_test.go
@@ -9,6 +9,91 @@ import (
 	"tailscale.com/tailcfg"
 )
 
+func TestHandleRedirect(t *testing.T) {
+	tests := []struct {
+		name         string
+		hostname     string
+		enableTLS    bool
+		reqHost      string
+		target       string
+		wantRedirect bool
+		wantLocation string
+	}{
+		{
+			name:         "wrong host redirects https",
+			hostname:     "app.example.ts.net",
+			enableTLS:    true,
+			reqHost:      "wrong.example.ts.net",
+			target:       "/foo?x=1",
+			wantRedirect: true,
+			wantLocation: "https://app.example.ts.net/foo?x=1",
+		},
+		{
+			name:         "wrong host with port redirects http",
+			hostname:     "app.example.ts.net",
+			enableTLS:    false,
+			reqHost:      "wrong.example.ts.net:8080",
+			target:       "/bar",
+			wantRedirect: true,
+			wantLocation: "http://app.example.ts.net/bar",
+		},
+		{
+			name:         "matching host does not redirect",
+			hostname:     "app.example.ts.net",
+			enableTLS:    true,
+			reqHost:      "app.example.ts.net",
+			target:       "/ok",
+			wantRedirect: false,
+		},
+		{
+			name:         "matching host with port does not redirect",
+			hostname:     "app.example.ts.net",
+			enableTLS:    true,
+			reqHost:      "app.example.ts.net:443",
+			target:       "/ok",
+			wantRedirect: false,
+		},
+		{
+			name:         "empty host does not redirect",
+			hostname:     "app.example.ts.net",
+			enableTLS:    true,
+			reqHost:      "",
+			target:       "/ok",
+			wantRedirect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewHTTP(HTTPOptions{
+				Hostname:  tt.hostname,
+				EnableTLS: tt.enableTLS,
+			})
+			// Server-style request: path-only URL, host only on Request.Host.
+			req := httptest.NewRequest(http.MethodGet, tt.target, nil)
+			req.Host = tt.reqHost
+			if req.URL.Host != "" {
+				t.Fatalf("precondition: URL.Host = %q, want empty for server-style request", req.URL.Host)
+			}
+
+			rec := httptest.NewRecorder()
+			got := h.handleRedirect(rec, req)
+			if got != tt.wantRedirect {
+				t.Fatalf("handleRedirect = %v, want %v", got, tt.wantRedirect)
+			}
+			if !tt.wantRedirect {
+				return
+			}
+			if rec.Code != http.StatusMovedPermanently {
+				t.Errorf("status = %d, want %d", rec.Code, http.StatusMovedPermanently)
+			}
+			if loc := rec.Header().Get("Location"); loc != tt.wantLocation {
+				t.Errorf("Location = %q, want %q", loc, tt.wantLocation)
+			}
+		})
+	}
+}
+
 func TestSetTailscaleHeadersSanitization(t *testing.T) {
 	userInfo := &apitype.WhoIsResponse{
 		UserProfile: &tailcfg.UserProfile{


### PR DESCRIPTION
## Problem

`handleRedirect` compared `r.URL.Hostname()` to the configured hostname. On server-side requests Go leaves `Request.URL.Host` empty and puts the client host in `Request.Host`, so the redirect never ran when a client used the wrong host.

## Change

- Read the request host from `r.Host`, strip an optional port with `net.SplitHostPort`, and compare to `opts.Hostname`.
- Redirect scheme still comes from `EnableTLS`.
- Table-driven tests use server-style requests (path-only URL + Host header) for wrong host, matching host (with/without port), and empty host.

## Verified

```
go test ./pkg/handler/...
go test ./...
```