### PR TITLE
fix(nixos): align systemd slice name with service Slice

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -195,7 +195,7 @@ in
 
     systemd.tmpfiles.rules = [ "d ${cfg.dataDir} 0700 ${cfg.user} ${cfg.group} - -" ];
 
-    systemd.slices.ts-proxys.sliceConfig = {
+    systemd.slices.ts-proxy.sliceConfig = {
       CPUQuota = "10%";
       MemoryHigh = "256M";
       MemoryMax = "384M";


### PR DESCRIPTION
## Summary

- Renames `systemd.slices.ts-proxys` → `systemd.slices.ts-proxy` so it matches `serviceConfig.Slice = "ts-proxy.slice"`.
- Without this, the service never joins the resource-limited slice; `CPUQuota` / `MemoryHigh` / `MemoryMax` are dead config.

## Test plan

- [x] Inspected attr path and `Slice` assignment agree on `ts-proxy`
- [ ] Reviewer: enable module and confirm unit lands in `ts-proxy.slice` (`systemctl show -p Slice <service>`)

Finding: `nixos-slice-typo`