### PR TITLE
fix: remove dead mise-ci version ldflags from GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - -s -w -X github.com/lucasew/mise-ci/internal/version.version={{ .Version }}
+      - -s -w
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
## Summary

GoReleaser was injecting `-X github.com/lucasew/mise-ci/internal/version.version={{ .Version }}` into `ts-proxyd` builds. That package path is from another project; this module is `github.com/lucasew/ts-proxy` and has no matching version var, so the flag was a no-op leftover.

Left the useful strip flags (`-s -w`). Did not add a version package or wire cobra — only removed the wrong `-X`.

## Verify

- `goreleaser check` on `.goreleaser.yaml` passes

@lucasew