### PR TITLE
fix(docker): run ts-proxyd container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM alpine:3.24@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 
-RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables
+RUN apk add --no-cache ca-certificates iptables iproute2 ip6tables \
+	&& addgroup -g 65532 -S tsproxy \
+	&& adduser -u 65532 -S -D -H -h /var/lib/ts-proxy -G tsproxy tsproxy \
+	&& mkdir -p /var/lib/ts-proxy \
+	&& chown tsproxy:tsproxy /var/lib/ts-proxy
 
 ARG TARGETPLATFORM
 COPY $TARGETPLATFORM/ts-proxyd /usr/local/bin/ts-proxyd
 
+USER 65532:65532
+
 ENTRYPOINT [ "/usr/local/bin/ts-proxyd" ]
 
 CMD [ "server" ]
-


### PR DESCRIPTION
## Problem

The image had no `USER` directive, so the entrypoint ran as root. That is more privilege than the process needs for the default tsnet proxy path.

## Change

- Create system user/group `tsproxy` (UID/GID **65532**)
- Pre-create `/var/lib/ts-proxy` owned by that user
- `USER 65532:65532` before the entrypoint
- Keep `ca-certificates` and the networking packages (iptables/iproute2/ip6tables) for Tailscale/tsnet support

## Privileged ports / Funnel

Handlers call `tsnet` `Listen` / `ListenTLS` / `ListenFunnel`, not host `net.Listen`. Default `:80` / `:443` (and Funnel) are on the Tailscale virtual stack, so they do **not** need root or `CAP_NET_BIND_SERVICE` on the host.

If you ever bind real host ports below 1024 outside tsnet, run with something like `cap_add: [NET_BIND_SERVICE]` or use high ports. That is not the default path for this binary.

## Ops note (behavior)

State dir must be writable by **UID/GID 65532**. Existing volume mounts owned only by another user need a one-time `chown` (or matching `user:` on the container). Host networking for reaching host upstreams is unchanged.

## Verify

- Diff limited to `Dockerfile`
- Confirmed listen path in `pkg/server/server.go` uses tsnet listeners only
- Could not pull alpine in this environment to build-smoke the user creation lines; flags match busybox/Alpine `adduser`/`addgroup`
